### PR TITLE
Updated Readme to include 0b05:1866

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Linux-compatible open-source libusb implementation similar to the ROG
 Aura Core software.  Supports RGB keyboards with IDs
 [0b05:1854](https://linux-hardware.org/index.php?id=usb:0b05-1854)
-(GL553 and GL753),
+(GL553, GL753),
 [0b05:1869](https://linux-hardware.org/index.php?id=usb:0b05-1869)
 (GL503, FX503, GL703) and [0b05:1866](https://linux-hardware.org/index.php?id=usb:0b05-1866) (GL504, GL703, GX501, GM501).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Aura Core software.  Supports RGB keyboards with IDs
 [0b05:1854](https://linux-hardware.org/index.php?id=usb:0b05-1854)
 (GL553 and GL753),
 [0b05:1869](https://linux-hardware.org/index.php?id=usb:0b05-1869)
-(GL503, FX503, GL703) and [0b05:1866] (GM501).
+(GL503, FX503, GL703) and [0b05:1866](https://linux-hardware.org/index.php?id=usb:0b05-1866) (GL504, GL703, GX501, GM501).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 Linux-compatible open-source libusb implementation similar to the ROG
 Aura Core software.  Supports RGB keyboards with IDs
 [0b05:1854](https://linux-hardware.org/index.php?id=usb:0b05-1854)
-(GL553 and GL753) and
+(GL553 and GL753),
 [0b05:1869](https://linux-hardware.org/index.php?id=usb:0b05-1869)
-(GL503, FX503, GL703).
+(GL503, FX503, GL703) and [0b05:1866] (GM501).
 
 ## Usage
 


### PR DESCRIPTION
Updated the Readme to include the USB ID 0b05:1866 and it's various registered models (through linux-hardware.org). This is a follow up to pull #2 