### PR TITLE
Added initial support for udev rules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,6 @@
 ## Makefile.am -- Process this file with automake to produce Makefile.in
 bin_PROGRAMS = rogauracore
 rogauracore_SOURCES = src/rogauracore.c
-EXTRA_DIST = LICENSE.md README.md
+EXTRA_DIST = LICENSE.md README.md $(srcdir)/90-rogauracore.rules
+#udevrulesdir = $(udevdir)/rules.d
+udevrules_DATA = data/90-rogauracore.rules

--- a/configure.ac
+++ b/configure.ac
@@ -6,9 +6,46 @@ AC_CONFIG_SRCDIR([src/rogauracore.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([1.9 foreign subdir-objects])
+WITH_UDEV=yes
 
 # Checks for programs.
 AC_PROG_CC
+
+# Set udevdir for udev rules
+AC_ARG_WITH([udev],
+	[AS_HELP_STRING([--with-udev],
+		[Enable udev integration])],
+	[WITH_UDEV=$withval])
+AC_SUBST(WITH_UDEV)
+# set default early
+default_udevdir=/lib/udev
+if test x"$with_udev" = x || \
+   test x"$with_udev" = xyes ; then
+	if test x"$PKG_CONFIG" != x; then
+		udevdir=$($PKG_CONFIG --variable=udevdir udev)
+	fi
+	if test x"$udevdir" = x; then
+		AC_MSG_NOTICE([Could not detect udev rules directory, using default])
+		udevdir=$default_udevdir
+	fi
+	AC_MSG_RESULT([Using udev rules directory: $udevdir])
+else
+	udevdir=$default_udevdir
+fi
+dnl always replace, even if not used
+AC_SUBST(udevdir)
+udevrulesdir=$udevdir/rules.d
+AC_SUBST(udevrulesdir)
+dnl checks for programs
+AC_PATH_PROG(UDEVADM, udevadm, [false], [/sbin$PATH_SEPARATOR$PATH])
+AC_PATH_PROG(UDEVINFO, udevinfo, [false], [/sbin$PATH_SEPARATOR$PATH])
+if test $UDEVADM = false && test $UDEVINFO = false; then
+   if test "$WITH_UDEV" = "yes"; then
+     AC_MSG_WARN([udev support enabled, but neither udevadm nor udevinfo found on this system.])
+   fi
+fi
+dnl Checks for system services
+UDEV_RULE_SUFFIX=""
 
 # Checks for libraries.
 AC_SEARCH_LIBS([libusb_init], [usb-1.0])
@@ -26,5 +63,11 @@ AC_TYPE_UINT8_T
 # Checks for library functions.
 AC_CHECK_FUNCS([memset strtol])
 
+AM_CONDITIONAL(INSTALL_UDEV_RULES, test x$with_udevdir != xno)
+AC_SUBST(UDEV_RULE_SUFFIX)
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
+
+echo \
+        udev dir:                 ${with_udevdir}

--- a/data/90-rogauracore.rules
+++ b/data/90-rogauracore.rules
@@ -1,0 +1,8 @@
+# udev rules for user control over ROG USB RGB keyboard backlight control (i.e "ROG Aura Core")
+
+# GL553, GL753
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1854", MODE="0666", TAG+="uaccess"
+# GL503, FX503, GL703
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1869", MODE="0666", TAG+="uaccess"
+# GL504, GL703, GX501, GM501
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1866", MODE="0666", TAG+="uaccess"


### PR DESCRIPTION
Edited the `Makefile.am` and `Configure.ac` to check that udev is available 
on the system and that the administrative tool can be used. The only thing
missing so far is using udevadm to update the current rules...

However: I found that using udevadm (on my system at least) did not
work and I was forced to reboot. I will return to this issue after
I've removed the rules from my computer and attempted building again.
The code in both `Makefile.am` and `configure.ac` was copy-pasted
from this example:

https://fossies.org/linux/drbd-utils/configure.ac

The rule file is simple:
1. It finds the vendor and ID of USB devices
2. Sets chmod to '666' (not sure if that's a good idea)
3. Added TAG+="uaccess" for good measure.

The rule file itself might need some more tweaking to make it secure
and usable.