### PR TITLE
support for 2021 Zephyrus G15

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Aura Core software.  Supports RGB keyboards with IDs
 [0b05:1854](https://linux-hardware.org/index.php?id=usb:0b05-1854)
 (GL553, GL753),
 [0b05:1869](https://linux-hardware.org/index.php?id=usb:0b05-1869)
-(GL503, FX503, GL703) and [0b05:1866](https://linux-hardware.org/index.php?id=usb:0b05-1866) (GL504, GL703, GX501, GM501).
+(GL503, FX503, GL703), [0b05:1866](https://linux-hardware.org/index.php?id=usb:0b05-1866) (GL504, GL703, GX501, GM501), and [0b05:19b6](https://linux-hardware.org/index.php?id=usb:0b05-19b6) (GA503).
 
 ## Usage
 

--- a/src/rogauracore.c
+++ b/src/rogauracore.c
@@ -466,7 +466,7 @@ parseArguments(int argc, char **argv, Messages *messages) {
 // ------------------------------------------------------------
 
 const uint16_t ASUS_VENDOR_ID = 0x0b05;
-const uint16_t ASUS_PRODUCT_IDS[] = { 0x1854, 0x1869, 0x1866 };
+const uint16_t ASUS_PRODUCT_IDS[] = { 0x1854, 0x1869, 0x1866, 0x19b6 };
 const int NUM_ASUS_PRODUCTS = (int)(sizeof(ASUS_PRODUCT_IDS) / sizeof(ASUS_PRODUCT_IDS[0]));
 
 int


### PR DESCRIPTION
Adding 0x19b6 from lsusb output to ASUS_PRODUCT_IDS enables compatibility with 2021 ROG Zephyrus G15 (GA503QR), easy fix :)