### PR TITLE
Update README.md according to #82

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ send an initialisation message to the keyboard to "wake it up":
 sudo rogauracore initialize_keyboard
 ```
 
+If your keyboard remains dark, its brightness might have defaulted to 0. Try:
+
+```
+sudo rogauracore brightness 3
+```
+
 ## Building
 
 ### On Ubuntu from a release:


### PR DESCRIPTION
If the keyboard's lights default to a brightness of 0 when booting into Linux, the user might mistakenly think their commands are not correctly sent or interpreted. This confusion is especially likely to occur if the brightness defaults to a higher value when booting into e.g. Windows. I've updated the README to instruct users to try the brightness command in case their keyboard remains dark. 

Closes #82