### PR TITLE
Add support for ROG Flow Z13 (2025) detachable keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Aura Core software.  Supports RGB keyboards with IDs
 [0b05:1854](https://linux-hardware.org/index.php?id=usb:0b05-1854)
 (GL553, GL753),
 [0b05:1869](https://linux-hardware.org/index.php?id=usb:0b05-1869)
-(GL503, FX503, GL703), [0b05:1866](https://linux-hardware.org/index.php?id=usb:0b05-1866) (GL504, GL533, GL703, GX501, GM501), and [0b05:19b6](https://linux-hardware.org/index.php?id=usb:0b05-19b6) (GA503).
+(GL503, FX503, GL703), [0b05:1866](https://linux-hardware.org/index.php?id=usb:0b05-1866) (GL504, GL533, GL703, GX501, GM501), [0b05:19b6](https://linux-hardware.org/index.php?id=usb:0b05-19b6) (GA503)
+and [0b05:1a30](https://linux-hardware.org/index.php?id=usb:0b05-1a30) (GZ302EA).
 
 ## Usage
 

--- a/src/rogauracore.c
+++ b/src/rogauracore.c
@@ -481,7 +481,7 @@ parseArguments(int argc, char **argv, Messages *messages) {
 // ------------------------------------------------------------
 
 const uint16_t ASUS_VENDOR_ID = 0x0b05;
-const uint16_t ASUS_PRODUCT_IDS[] = { 0x1854, 0x1869, 0x1866, 0x19b6 };
+const uint16_t ASUS_PRODUCT_IDS[] = { 0x1854, 0x1869, 0x1866, 0x19b6, 0x1a30 };
 const int NUM_ASUS_PRODUCTS = (int)(sizeof(ASUS_PRODUCT_IDS) / sizeof(ASUS_PRODUCT_IDS[0]));
 
 int


### PR DESCRIPTION
This PR adds support for the ROG Flow Z13 (2025) detachable keyboard.

This keyboard cannot currently be controlled by other tools such as OpenRGB or asusctl. It works perfectly with this tool when the patch is applied.