### PR TITLE
Add rog-auracore-gui to related projects...

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,5 +115,10 @@ sudo systemctl restart upower.service
   is an Electron-based GUI for `rogauracore` by
   [@rastafaninplakeibol](https://github.com/rastafaninplakeibol).
 
+- [rog-auracore-gui](https://gitlab.com/bytecode-solutions/community/rog-auracore-gui)
+  is a native GTK3 GUI for `rogauracore` by
+  [@alek.cora.glez](https://gitlab.com/alek.cora.glez), installable via
+  [PPA](https://launchpad.net/~alek.cora.glez/+archive/ubuntu/rog-auracore-gui).
+
 - [OpenRGB](https://gitlab.com/CalcProgrammer1/OpenRGB) can probably
   do all the things that `rogauracore` can do.


### PR DESCRIPTION
Adds [rog-auracore-gui](https://gitlab.com/bytecode-solutions/community/rog-auracore-gui) to the Related projects section. A native GTK3 front-end for rogauracore, installable on Ubuntu via PPA:
  - sudo add-apt-repository ppa:alek.cora.glez/rog-auracore-gui
  - sudo apt install rog-auracore-gui
